### PR TITLE
fix: check context before first fn call in RunWithOutcome

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -210,6 +210,17 @@ func (b *Breaker) RunWithOutcome(ctx context.Context, fn func(attempt int) Resul
 			}
 
 			delay *= b.factor
+		} else {
+			// First attempt: check for pre-cancelled context before calling fn,
+			// matching DoWithOutcome's behavior.
+			select {
+			case <-ctx.Done():
+				return Outcome{
+					Err:     ctx.Err(),
+					Latency: time.Since(start),
+				}
+			default:
+			}
 		}
 
 		r := fn(try)

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -499,14 +499,17 @@ func TestRunWithOutcome(t *testing.T) {
 		cancel()
 
 		br := New(nil, 50*time.Millisecond, 1, 3)
+		called := false
 		out := br.RunWithOutcome(ctx, func(_ int) Result {
+			called = true
 			return OK()
 		})
 
-		// fn is called despite cancelled context (same as Do behaviour —
-		// context is checked before backoff sleep, not before first call)
-		assert.NoError(t, out.Err)
-		assert.Equal(t, 1, out.Attempts)
+		// Pre-cancelled context should return ctx.Err() without calling fn,
+		// matching DoWithOutcome's behavior.
+		assert.ErrorIs(t, out.Err, context.Canceled)
+		assert.Equal(t, 0, out.Attempts)
+		assert.False(t, called, "fn should not be called when context is already cancelled")
 	})
 
 	t.Run("ContextCanceledDuringBackoff", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes behavioral asymmetry between `DoWithOutcome` and `RunWithOutcome` on pre-cancelled context.

**Before:** `DoWithOutcome` checks `ctx.Done()` before every `fn()` call (including the first), returning `ctx.Err()` with `Attempts=0`. `RunWithOutcome` skipped this check on the first attempt (`try == 0`), calling `fn(0)` even with a cancelled context — potentially succeeding with `Attempts=1`.

**After:** `RunWithOutcome` adds a `select` on `ctx.Done()` before the first `fn(0)` call, matching `DoWithOutcome`'s behavior.

## Changes

- `breaker.go`: Add context cancellation check in the `try == 0` branch of `RunWithOutcome`
- `breaker_test.go`: Update `ContextCanceledBeforeStart` test to assert the corrected behavior (`Attempts=0`, `ctx.Canceled` error, `fn` not called)

## Test plan

- [x] All existing tests pass unchanged (except the one that asserted the old broken behavior)
- [x] `ContextCanceledBeforeStart` now verifies `fn` is NOT called when context is pre-cancelled
- [x] Full suite: `go test -race -v -count=1 ./...` — PASS

🤖 Generated with [Claude Code](https://claude.ai/code)