### PR TITLE
fix: check context cancellation before first fn call in RunWithOutcome

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -193,6 +193,19 @@ func (b *Breaker) RunWithOutcome(ctx context.Context, fn func(attempt int) Resul
 	var lastErr error
 
 	for try := range b.maxTries + 1 {
+		// Check for context cancellation before each attempt,
+		// including the first — matching DoWithOutcome behaviour.
+		select {
+		case <-ctx.Done():
+			return Outcome{
+				Err:      ctx.Err(),
+				Attempts: try,
+				Retried:  try > 1,
+				Latency:  time.Since(start),
+			}
+		default:
+		}
+
 		if try > 0 {
 			sleepDur := b.applyJitter(time.Duration(int64(delay)))
 

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -500,13 +500,14 @@ func TestRunWithOutcome(t *testing.T) {
 
 		br := New(nil, 50*time.Millisecond, 1, 3)
 		out := br.RunWithOutcome(ctx, func(_ int) Result {
+			t.Fatal("fn should not be called when context is already cancelled")
 			return OK()
 		})
 
-		// fn is called despite cancelled context (same as Do behaviour —
-		// context is checked before backoff sleep, not before first call)
-		assert.NoError(t, out.Err)
-		assert.Equal(t, 1, out.Attempts)
+		// Matches DoWithOutcome: returns ctx.Err() with Attempts=0
+		assert.ErrorIs(t, out.Err, context.Canceled)
+		assert.Equal(t, 0, out.Attempts)
+		assert.False(t, out.Retried)
 	})
 
 	t.Run("ContextCanceledDuringBackoff", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `RunWithOutcome` now checks `ctx.Done()` before every attempt (including the first), matching the existing `DoWithOutcome` behaviour
- Previously `Run`/`RunWithOutcome` would call `fn(0)` even with an already-cancelled context, while `Do`/`DoWithOutcome` would return `ctx.Err()` with `Attempts=0`
- Updated the `ContextCanceledBeforeStart` test to assert the corrected behaviour

## Details

`DoWithOutcome` has a `select { case <-ctx.Done(): ... }` guard at the top of the loop (before calling `fn()`), so a pre-cancelled context returns immediately with `ctx.Err()` and `Attempts=0`.

`RunWithOutcome` lacked this guard — it went straight to `fn(try)` on the first iteration. This meant a pre-cancelled context could still execute the user's function and return success with `Attempts=1`, which is inconsistent and surprising.

The fix adds the same `select` check before each `fn(try)` call in `RunWithOutcome`.

## Test plan

- [x] `TestRunWithOutcome/ContextCanceledBeforeStart` updated to assert `Attempts=0` and `context.Canceled` error (matching `DoWithOutcome`)
- [x] All existing tests pass unchanged
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)